### PR TITLE
naze32: serial: fix non-ppm+serial option

### DIFF
--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -492,6 +492,7 @@ void PIOS_Board_Init(void) {
 		case HWNAZE_RCVRPORT_PPM:
 		case HWNAZE_RCVRPORT_PPMPWM:
 		case HWNAZE_RCVRPORT_PPMSERIAL:
+		case HWNAZE_RCVRPORT_SERIAL:
 			PIOS_Servo_Init(&pios_servo_cfg);
 			break;
 		case HWNAZE_RCVRPORT_PPMOUTPUTS:


### PR DESCRIPTION
I've missed this line before on targets.  It's a subtlety with the OUTPUTS: options
